### PR TITLE
Correctly decode mb_u_int32 length of opaque data

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -2,6 +2,20 @@
 
 var codePageLoader = require('./codepage');
 
+function decode_mb_u_int32(buf, pos) {
+	const out = { val: 0, len: 0 };
+
+	let b;
+	do {
+		out.len += 1;
+		b = buf[pos + out.len - 1];
+		out.val <<= 7;
+		out.val += b & 127;
+	} while (b & 128);
+
+	return out;
+}
+
 function decode(buf, codePage) {
 	if (typeof codePage === 'string') {
 		codePage = codePageLoader(codePage);
@@ -40,8 +54,10 @@ function parseTag(buf, pos, codePage, currentCodePage) {
 			pos = strEndIdx;
 		} else if (oct === 195) {
 			//opaque data
-			var dataLength = buf.readUInt32BE(++pos);
-			pos += 4;
+			var parsedMultiByte = decode_mb_u_int32(buf, ++pos);
+			var dataLength = parsedMultiByte.val;
+			// Jump over the multi-byte integer's bytes
+			pos += parsedMultiByte.len;
 
 			if (dataLength > 0) {
 				tag['_'] = '<![CDATA[' + buf.toString('base64', pos, pos + dataLength) + ']]>';


### PR DESCRIPTION
OPAQUE data length is encoded as a multi-byte 32-bit, big-endian unsigned integer and as such we have to count the number bytes that make up the integer, since they are not always four.